### PR TITLE
pymongo 4.8.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+extra_labels_for_os:
+  osx-arm64: [ventura]

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/hatch-requirements-txt-feedstock/pr2/3453df3
+  - https://staging.continuum.io/prefect/fs/mockupdb-feedstock/pr1/cd01e01

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/hatch-requirements-txt-feedstock/pr2/3453df3
-  - https://staging.continuum.io/prefect/fs/mockupdb-feedstock/pr1/cd01e01

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -77,7 +77,6 @@ requirements:
 test:
   source_files:
     - test
-    - mypy_test.ini
   imports:
     - bson
     - gridfs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,15 +34,11 @@ requirements:
   run_constrained:
     - pymongo-auth-aws >=1.1.0,<2.0.0
     - pymongocrypt >=1.6.0,<2.0.0
-    - certifi             # [win or osx]
-    - pykerberos          # [not win]
     - winkerberos >=0.5.0 # [win]
     - pyopenssl >=17.2.0
     - requests <3.0.0
     - cryptography >=2.5
     - service_identity >=18.1.0
-    - python-snappy
-    - zstandard
 
 {% set tests_to_ignore = "" %}
 # It is now a ConfigurationError to not have pymongo_auth_aws

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,6 @@ source:
 
 build:
   number: 0
-  # osx-arm64: "pymongo 4.8.0 is not supported on this platform"
   skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   ignore_run_exports:
@@ -53,18 +52,18 @@ requirements:
 # It is now a ConfigurationError to not have pymongo_auth_aws
 {% set tests_to_ignore = tests_to_ignore + " --ignore=test/auth_aws/test_auth_aws.py" %}
 # pymongo.errors.ServerSelectionTimeoutError
-{% set tests_to_ignore = tests_to_ignore + " --ignore test/mod_wsgi_test/mod_wsgi_test.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=test/mod_wsgi_test/mod_wsgi_test.py" %}
 # We don't have the test/performance/data files
-{% set tests_to_ignore = tests_to_ignore + " --ignore test/performance/perf_test.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=test/performance/perf_test.py" %}
 # We don't have a mongodb instance
-{% set tests_to_ignore = tests_to_ignore + " --ignore test/auth_oidc/test_auth_oidc.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=test/auth_oidc/test_auth_oidc.py" %}
 # We don't have an atlas instance (mongodb in the cloud)
-{% set tests_to_ignore = tests_to_ignore + " --ignore test/atlas/test_connection.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=test/atlas/test_connection.py" %}
 # We don't have an OCSP instance (Online Certificate Status Protocol)
-{% set tests_to_ignore = tests_to_ignore + " --ignore test/ocsp/test_ocsp.py" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=test/ocsp/test_ocsp.py" %}
 
 # No mockupdb for s390x
-{% set tests_to_ignore = tests_to_ignore + " --ignore test/mockupdb" %}  # [s390x]
+{% set tests_to_ignore = tests_to_ignore + " --ignore=test/mockupdb" %}  # [s390x]
 
 {% set tests_to_skip = "" %}
 # The test is expecting to be running under  kubernetes?

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - pip
     - wheel
     - setuptools >=65.0
+    # we only have 1.21.1 at the moment, and it seems to work
     - hatchling # >1.24
     - hatch-requirements-txt >=0.4.1
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ source:
   fn: pymongo-{{ version }}.tar.gz
   url: https://github.com/mongodb/mongo-python-driver/archive/{{ version }}.tar.gz
   sha256: 3639d459b06257b529c5675bb68e0f89d4a4d77fe5f76c01107202c3ba52d4cb
+  patches:
+    - patches/0001-generate-normalized-platform-tag.patch
 
 build:
   number: 0
@@ -22,6 +24,8 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - patch     # [not win]
+    - m2-patch  # [win]
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,8 +8,8 @@ source:
   fn: pymongo-{{ version }}.tar.gz
   url: https://github.com/mongodb/mongo-python-driver/archive/{{ version }}.tar.gz
   sha256: 3639d459b06257b529c5675bb68e0f89d4a4d77fe5f76c01107202c3ba52d4cb
-  patches:
-    - patches/0001-generate-normalized-platform-tag.patch
+  patches:                                                 # [osx and arm64]
+    - patches/0001-generate-normalized-platform-tag.patch  # [osx and arm64]
 
 build:
   number: 0
@@ -19,8 +19,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - patch     # [not win]
-    - m2-patch  # [win]
+    - patch     # [osx and arm64]
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  # osx-arm64: "pymongo 4.8.0 is not supported on this platform"
   skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   ignore_run_exports:
@@ -58,11 +59,17 @@ requirements:
 # We don't have an OCSP instance (Online Certificate Status Protocol)
 {% set tests_to_ignore = tests_to_ignore + " --ignore test/ocsp/test_ocsp.py" %}
 
+# No mockupdb for s390x
+{% set tests_to_ignore = tests_to_ignore + " --ignore test/mockupdb" %}  # [s390x]
+
 {% set tests_to_skip = "" %}
 # The test is expecting to be running under  kubernetes?
 {% set tests_to_skip = tests_to_skip + "test_container_metadata" %}
 # A less than obvious AssertionError
 {% set tests_to_skip = tests_to_skip + " or test_metadata" %}
+# AssertionError (got nothing)
+{% set tests_to_skip = tests_to_skip + " or test_initial_ismaster" %}  # [win-64 or (osx and x86)]
+
 
 test:
   source_files:
@@ -75,7 +82,7 @@ test:
   requires:
     - pip
     - pytest >=7
-    - mockupdb
+    - mockupdb  # [not s390x]
   commands:
     - pip check
     - pytest -v . {{ tests_to_ignore }} -k "not ({{ tests_to_skip }})"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,14 +15,10 @@ build:
   number: 0
   skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  ignore_run_exports:
-    - python
-    - libstdcxx-ng
 
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
     - patch     # [not win]
     - m2-patch  # [win]
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.6.3" %}
+{% set version = "4.8.0" %}
 
 package:
   name: pymongo
@@ -7,12 +7,15 @@ package:
 source:
   fn: pymongo-{{ version }}.tar.gz
   url: https://github.com/mongodb/mongo-python-driver/archive/{{ version }}.tar.gz
-  sha256: c3b1be222869a35fee67714b754ebe8c5e83553b34ec60a6e8870ba0ea4f4496
+  sha256: 3639d459b06257b529c5675bb68e0f89d4a4d77fe5f76c01107202c3ba52d4cb
 
 build:
   number: 0
-  skip: true  # [py<37]
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -v
+  skip: true  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  ignore_run_exports:
+    - python
+    - libstdcxx-ng
 
 requirements:
   build:
@@ -22,23 +25,49 @@ requirements:
     - python
     - pip
     - wheel
-    - setuptools
+    - setuptools >=65.0
+    - hatchling # >1.24
+    - hatch-requirements-txt >=0.4.1
   run:
     - python
     - dnspython >=1.16.0,<3.0.0
   run_constrained:
-    - pymongo-auth-aws <2.0.0
+    - pymongo-auth-aws >=1.1.0,<2.0.0
     - pymongocrypt >=1.6.0,<2.0.0
+    - certifi             # [win or osx]
+    - pykerberos          # [not win]
     - winkerberos >=0.5.0 # [win]
     - pyopenssl >=17.2.0
     - requests <3.0.0
     - cryptography >=2.5
     - service_identity >=18.1.0
+    - python-snappy
+    - zstandard
+
+{% set tests_to_ignore = "" %}
+# It is now a ConfigurationError to not have pymongo_auth_aws
+{% set tests_to_ignore = tests_to_ignore + " --ignore=test/auth_aws/test_auth_aws.py" %}
+# pymongo.errors.ServerSelectionTimeoutError
+{% set tests_to_ignore = tests_to_ignore + " --ignore test/mod_wsgi_test/mod_wsgi_test.py" %}
+# We don't have the test/performance/data files
+{% set tests_to_ignore = tests_to_ignore + " --ignore test/performance/perf_test.py" %}
+# We don't have a mongodb instance
+{% set tests_to_ignore = tests_to_ignore + " --ignore test/auth_oidc/test_auth_oidc.py" %}
+# We don't have an atlas instance (mongodb in the cloud)
+{% set tests_to_ignore = tests_to_ignore + " --ignore test/atlas/test_connection.py" %}
+# We don't have an OCSP instance (Online Certificate Status Protocol)
+{% set tests_to_ignore = tests_to_ignore + " --ignore test/ocsp/test_ocsp.py" %}
+
+{% set tests_to_skip = "" %}
+# The test is expecting to be running under  kubernetes?
+{% set tests_to_skip = tests_to_skip + "test_container_metadata" %}
+# A less than obvious AssertionError
+{% set tests_to_skip = tests_to_skip + " or test_metadata" %}
 
 test:
   source_files:
     - test
-    - pytest.ini
+    - mypy_test.ini
   imports:
     - bson
     - gridfs
@@ -46,12 +75,13 @@ test:
   requires:
     - pip
     - pytest >=7
+    - mockupdb
   commands:
-    - pytest .
     - pip check
+    - pytest -v . {{ tests_to_ignore }} -k "not ({{ tests_to_skip }})"
 
 about:
-  home: https://github.com/mongodb/mongo-python-driver
+  home: https://www.mongodb.org
   license: Apache-2.0
   license_file: LICENSE
   license_family: Apache
@@ -62,7 +92,7 @@ about:
     BSON format for Python. The pymongo package is a native Python driver 
     for MongoDB. The gridfs package is a gridfs implementation on top of pymongo.
   dev_url: https://github.com/mongodb/mongo-python-driver
-  doc_url: https://pymongo.readthedocs.io/en/stable/index.html
+  doc_url: https://pymongo.readthedocs.io
 
 extra:
   recipe-maintainers:

--- a/recipe/patches/0001-generate-normalized-platform-tag.patch
+++ b/recipe/patches/0001-generate-normalized-platform-tag.patch
@@ -1,35 +1,33 @@
-From 96354b0f7276c2d2ba45d909fbe468b2e0aaa938 Mon Sep 17 00:00:00 2001
+From 4dbb273e297191514ba5b787e28fb302be396554 Mon Sep 17 00:00:00 2001
 From: Ian Fitchet <ifitchet@anaconda.com>
-Date: Tue, 10 Sep 2024 18:47:53 +0100
+Date: Wed, 11 Sep 2024 10:09:16 +0100
 Subject: [PATCH] generate normalized platform tag
 
 ---
- hatch_build.py | 10 ++++++++++
- 1 file changed, 10 insertions(+)
+ hatch_build.py | 8 ++++++++
+ 1 file changed, 8 insertions(+)
 
 diff --git a/hatch_build.py b/hatch_build.py
-index 91315eb0..26b1f1ca 100644
+index 91315eb0..416c2a7b 100644
 --- a/hatch_build.py
 +++ b/hatch_build.py
-@@ -7,8 +7,17 @@ import sys
+@@ -7,8 +7,15 @@ import sys
  from pathlib import Path
  
  from hatchling.builders.hooks.plugin.interface import BuildHookInterface
-+from packaging.tags import platform_tags
-+import sysconfig
++from packaging.tags import platform_tags, sys_tags
  
  
 +
 +def get_tag() -> str:
 +    """Get appropriate wheel tag according to system"""
 +    platform_tag = next(platform_tags())
-+    nodot = sysconfig.get_config_vars()['py_version_nodot']
-+    return f"cp{nodot}-cp{nodot}-{platform_tag}"
++    return str(next(tag for tag in sys_tags() if platform_tag == tag.platform))
 +
  class CustomHook(BuildHookInterface):
      """The pymongo build hook."""
  
-@@ -23,6 +32,7 @@ class CustomHook(BuildHookInterface):
+@@ -23,6 +30,7 @@ class CustomHook(BuildHookInterface):
  
          # Ensure wheel is marked as binary and contains the binary files.
          build_data["infer_tag"] = True

--- a/recipe/patches/0001-generate-normalized-platform-tag.patch
+++ b/recipe/patches/0001-generate-normalized-platform-tag.patch
@@ -1,0 +1,41 @@
+From 4a90fe1539f13d08f1b0a5e19a56da03240d07f4 Mon Sep 17 00:00:00 2001
+From: Ian Fitchet <ifitchet@anaconda.com>
+Date: Thu, 5 Sep 2024 18:44:17 +0100
+Subject: [PATCH] generate normalized platform tag
+
+---
+ hatch_build.py | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/hatch_build.py b/hatch_build.py
+index 91315eb0..261f2995 100644
+--- a/hatch_build.py
++++ b/hatch_build.py
+@@ -7,6 +7,14 @@ import sys
+ from pathlib import Path
+ 
+ from hatchling.builders.hooks.plugin.interface import BuildHookInterface
++from packaging.tags import platform_tags
++
++
++def get_tag() -> str:
++    """Get appropriate wheel tag according to system"""
++    platform_tag = next(platform_tags())
++    print(f"XXX TAG XXX py3-none-{platform_tag}", file=sys.stderr)
++    return f"py3-none-{platform_tag}"
+ 
+ 
+ class CustomHook(BuildHookInterface):
+@@ -22,7 +30,8 @@ class CustomHook(BuildHookInterface):
+         subprocess.check_call([sys.executable, "_setup.py", "build_ext", "-i"])
+ 
+         # Ensure wheel is marked as binary and contains the binary files.
+-        build_data["infer_tag"] = True
++        # build_data["infer_tag"] = True
++        build_data["tag"] = get_tag()
+         build_data["pure_python"] = False
+         if os.name == "nt":
+             patt = ".pyd"
+-- 
+2.39.3 (Apple Git-146)
+

--- a/recipe/patches/0001-generate-normalized-platform-tag.patch
+++ b/recipe/patches/0001-generate-normalized-platform-tag.patch
@@ -1,37 +1,38 @@
-From 4a90fe1539f13d08f1b0a5e19a56da03240d07f4 Mon Sep 17 00:00:00 2001
+From 96354b0f7276c2d2ba45d909fbe468b2e0aaa938 Mon Sep 17 00:00:00 2001
 From: Ian Fitchet <ifitchet@anaconda.com>
-Date: Thu, 5 Sep 2024 18:44:17 +0100
+Date: Tue, 10 Sep 2024 18:47:53 +0100
 Subject: [PATCH] generate normalized platform tag
 
 ---
- hatch_build.py | 11 ++++++++++-
- 1 file changed, 10 insertions(+), 1 deletion(-)
+ hatch_build.py | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
 
 diff --git a/hatch_build.py b/hatch_build.py
-index 91315eb0..261f2995 100644
+index 91315eb0..26b1f1ca 100644
 --- a/hatch_build.py
 +++ b/hatch_build.py
-@@ -7,6 +7,14 @@ import sys
+@@ -7,8 +7,17 @@ import sys
  from pathlib import Path
  
  from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 +from packaging.tags import platform_tags
-+
++import sysconfig
+ 
+ 
 +
 +def get_tag() -> str:
 +    """Get appropriate wheel tag according to system"""
 +    platform_tag = next(platform_tags())
-+    print(f"XXX TAG XXX py3-none-{platform_tag}", file=sys.stderr)
-+    return f"py3-none-{platform_tag}"
- 
- 
++    nodot = sysconfig.get_config_vars()['py_version_nodot']
++    return f"cp{nodot}-cp{nodot}-{platform_tag}"
++
  class CustomHook(BuildHookInterface):
-@@ -22,7 +30,8 @@ class CustomHook(BuildHookInterface):
-         subprocess.check_call([sys.executable, "_setup.py", "build_ext", "-i"])
+     """The pymongo build hook."""
+ 
+@@ -23,6 +32,7 @@ class CustomHook(BuildHookInterface):
  
          # Ensure wheel is marked as binary and contains the binary files.
--        build_data["infer_tag"] = True
-+        # build_data["infer_tag"] = True
+         build_data["infer_tag"] = True
 +        build_data["tag"] = get_tag()
          build_data["pure_python"] = False
          if os.name == "nt":


### PR DESCRIPTION
pymongo 4.8.0 

**Destination channel:** Defaults

### Links

- [PKG-5404]
- dev_url:        https://github.com/mongodb/mongo-python-driver/tree/4.8.0
- conda_forge:    https://github.com/conda-forge/pymongo-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/pymongo/4.8.0
- pypi inspector: https://inspector.pypi.io/project/pymongo/4.8.0

### Explanation of changes:

- new version number
- the minimum bound for `hatchling` has not been enforced (as we don't have it)
- this requires a patch to stop `pip check` believing that `osx-arm64` is not available
- wrangle with the tests (remove those with external requirements etc.)
- `abs.yaml`: force `osx-arm64` to use `ventura` - the build drops out without a message otherwise


[PKG-5404]: https://anaconda.atlassian.net/browse/PKG-5404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ