### PR TITLE
pymongo 4.15.5

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-extra_labels_for_os:
-  osx-arm64: [ventura]
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,5 @@
 {% set name = "pymongo" %}
 {% set version = "4.15.4" %}
-{% set deselected_tests = [
-  "--deselect=test/test_srv_polling.py::TestSrvPolling::test_dns_failures_logging"
-] %}
 
 package:
   name: {{ name|lower }}
@@ -37,6 +34,10 @@ requirements:
     - cryptography >=2.5
     - service_identity >=18.1.0
 
+{% set deselected_tests = [
+  "--deselect=test/test_srv_polling.py::TestSrvPolling::test_dns_failures_logging"
+] %}
+
 test:
   source_files:
     - test
@@ -48,7 +49,8 @@ test:
   requires:
     - pip
     - pytest >=8.2
-    - mockupdb
+    # mockupdb is not maintained and not available for Python 3.14 and later
+    - mockupdb  # [py<314]
     - pytest-asyncio >=0.24.0
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/mongodb/mongo-python-driver/archive/{{ version }}.tar.gz
-  sha256: 3a8d6bf2610abe0c97c567cf98bf5bba3e90ccc93cc03c9dde75fa11e4267b42
+  sha256: mockupdb is not maintained and not available for Python 3.14 and later
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pymongo" %}
-{% set version = "4.15.4" %}
+{% set version = "4.15.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/mongodb/mongo-python-driver/archive/{{ version }}.tar.gz
-  sha256: cb6490e009b8f8dcc12b074774dd3673c0d721fabcfbe8c93db9e4a4ed017162
+  sha256: 3a8d6bf2610abe0c97c567cf98bf5bba3e90ccc93cc03c9dde75fa11e4267b42
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,8 @@
 {% set name = "pymongo" %}
 {% set version = "4.15.4" %}
+{% set deselected_tests = [
+  "--deselect=test/test_srv_polling.py::TestSrvPolling::test_dns_failures_logging"
+] %}
 
 package:
   name: {{ name|lower }}
@@ -10,7 +13,7 @@ source:
   sha256: cb6490e009b8f8dcc12b074774dd3673c0d721fabcfbe8c93db9e4a4ed017162
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
@@ -34,9 +37,6 @@ requirements:
     - cryptography >=2.5
     - service_identity >=18.1.0
 
-{% set deselected_tests = [
-  "--deselect=test/test_srv_polling.py::TestSrvPolling::test_dns_failures_logging"
-]%}
 test:
   source_files:
     - test
@@ -52,8 +52,8 @@ test:
     - pytest-asyncio >=0.24.0
   commands:
     - pip check
-    - pytest -v test {{ deselected_tests | join(" ") }} # [win]
-    - pytest -v test # [not win]
+    - pytest -v test {{ deselected_tests | join(" ") }}  # [win]
+    - pytest -v test  # [not win]
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/mongodb/mongo-python-driver/archive/{{ version }}.tar.gz
-  sha256: mockupdb is not maintained and not available for Python 3.14 and later
+  sha256: 3a8d6bf2610abe0c97c567cf98bf5bba3e90ccc93cc03c9dde75fa11e4267b42
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/mongodb/mongo-python-driver/archive/{{ version }}.tar.gz
-  sha256: 3a8d6bf2610abe0c97c567cf98bf5bba3e90ccc93cc03c9dde75fa11e4267b42
+  sha256: 2975be5732bca75928afa7fdfac986a92322eeaa351a76e879901461fe351850
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-11339) 
- [Upstream repository](https://github.com/mongodb/mongo-python-driver/blob/4.15.5/pyproject.toml)

### Explanation of changes:

- Use mockupdb in tests only for py<314 because it is not maintained and not available for Python 3.14 and later

### Notes:

-